### PR TITLE
KAI - UI 구성하기

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,42 @@
 # swift-todo
 iOS 네번째 프로젝트
+
+<details>
+<summary>UI 구성하기</summary>
+
+## 🎯주요 작업
+
+- [x]  스토리보드에서 작업하기 - 오토레이 아웃 적용하기
+- [x]  카드 리스트 화면은 상단에 제목/배지/추가 버튼과 카드 목록을 표시하는 TableVIew 구성
+    - [x]  배지는 현재 카드 개수를 표시
+    - [x]  모서리가 없이 표시하고 숫자가 늘어나면 iOS 기본 배지처럼 가운데 영역길어짐
+    - [x]  카드 셀은 본문 내용을 3줄까지만 표시
+        - [x]  1줄 - 3줄까지 늘어나면 셀 높이도 같이 (self-resizing) 늘어나도록 구현
+
+## 📚학습 키워드
+
+### Anchor
+
+영어로 `닻` 이라는 뜻인데, 쉽게 View에 닻을 내려서 고정시킨다고 생각
+
+### **container view 사용 방법**
+
+1. parentVC.addChild(childVC): 특정 ViewController를 현재 ViewController의 자식으로 설정
+2. parentVC.view.addSubview(childView): 추가된 childVC의 View가 보일 수 있도록 맨 앞으로 등장하게 하는 것
+3. childVC.didMove(toParent: parentVC) / willMove: childVC입장에서는 언제 parentVC에 추가되는지 모르기 때문에, childVC에게 추가 및 제거 되는 시점을 알려주는 것 (willMove / didMove: 추가되기 전, 추가된 후)
+
+## 💻고민과 해결
+
+### **Logging Error: Failed to initialize logging system. Log messages may be missing. If this issue persists, try setting IDEPreferLogStreaming=YES in the active scheme actions environment variables.에러발생**
+
+[🧙‍♂️나의 해결] **`Product** -> **Scheme** -> **Edit Scheme → Arguments** 로 이동 -> **Arguments Passed On Launch** 에서 + 눌러서 아래와 같은 코드 입력 -> **Close** 클릭.`
+
+### 네비게이션 스토리보드로 제목 커스텀하기
+
+[🧙‍♂️나의 해결] 네비게이션바에 UIView 넣고 UILabel넣음
+
+## 🤔결과
+<img width="1077" alt="스크린샷 2024-04-10 오후 3 02 15" src="https://github.com/codesquad-members-2024/swift-todo/assets/104732020/9997f3ca-b0b6-44fa-8a9a-bc5a082154e8">
+
+</div>
+</details>

--- a/ToDoListApp/ToDoListApp.xcodeproj/project.pbxproj
+++ b/ToDoListApp/ToDoListApp.xcodeproj/project.pbxproj
@@ -114,7 +114,6 @@
 				D6349CC42BC3AAED002BAE5D /* AppDelegate.swift */,
 				D6349CC62BC3AAED002BAE5D /* SceneDelegate.swift */,
 				D6349CC82BC3AAED002BAE5D /* MainViewController.swift */,
-				D6349D022BC4FA37002BAE5D /* ContainerViewController.swift */,
 				D6349CFF2BC4DDFC002BAE5D /* CardList */,
 				D6349CFE2BC4D460002BAE5D /* Model */,
 				D6349CCA2BC3AAED002BAE5D /* Main.storyboard */,
@@ -153,6 +152,7 @@
 		D6349CFF2BC4DDFC002BAE5D /* CardList */ = {
 			isa = PBXGroup;
 			children = (
+				D6349D022BC4FA37002BAE5D /* ContainerViewController.swift */,
 				D6349CF62BC3C918002BAE5D /* CardListHeaderView.swift */,
 				D6349CF42BC3C8B8002BAE5D /* CardListViewController.swift */,
 				D6349CF82BC3DE2B002BAE5D /* CardTableViewCell.swift */,

--- a/ToDoListApp/ToDoListApp.xcodeproj/project.pbxproj
+++ b/ToDoListApp/ToDoListApp.xcodeproj/project.pbxproj
@@ -1,0 +1,658 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		D6349CC52BC3AAED002BAE5D /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6349CC42BC3AAED002BAE5D /* AppDelegate.swift */; };
+		D6349CC72BC3AAED002BAE5D /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6349CC62BC3AAED002BAE5D /* SceneDelegate.swift */; };
+		D6349CC92BC3AAED002BAE5D /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6349CC82BC3AAED002BAE5D /* MainViewController.swift */; };
+		D6349CCC2BC3AAED002BAE5D /* Base in Resources */ = {isa = PBXBuildFile; fileRef = D6349CCB2BC3AAED002BAE5D /* Base */; };
+		D6349CCE2BC3AAEE002BAE5D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D6349CCD2BC3AAEE002BAE5D /* Assets.xcassets */; };
+		D6349CD12BC3AAEE002BAE5D /* Base in Resources */ = {isa = PBXBuildFile; fileRef = D6349CD02BC3AAEE002BAE5D /* Base */; };
+		D6349CDC2BC3AAEF002BAE5D /* ToDoListAppTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6349CDB2BC3AAEF002BAE5D /* ToDoListAppTests.swift */; };
+		D6349CE62BC3AAEF002BAE5D /* ToDoListAppUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6349CE52BC3AAEF002BAE5D /* ToDoListAppUITests.swift */; };
+		D6349CE82BC3AAEF002BAE5D /* ToDoListAppUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6349CE72BC3AAEF002BAE5D /* ToDoListAppUITestsLaunchTests.swift */; };
+		D6349CF52BC3C8B8002BAE5D /* CardListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6349CF42BC3C8B8002BAE5D /* CardListViewController.swift */; };
+		D6349CF72BC3C918002BAE5D /* CardListHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6349CF62BC3C918002BAE5D /* CardListHeaderView.swift */; };
+		D6349CFA2BC3DE2B002BAE5D /* CardTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = D6349CF92BC3DE2B002BAE5D /* CardTableViewCell.xib */; };
+		D6349CFB2BC3DE2B002BAE5D /* CardTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6349CF82BC3DE2B002BAE5D /* CardTableViewCell.swift */; };
+		D6349CFD2BC4D45C002BAE5D /* TodoCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6349CFC2BC4D45C002BAE5D /* TodoCard.swift */; };
+		D6349D032BC4FA37002BAE5D /* ContainerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6349D022BC4FA37002BAE5D /* ContainerViewController.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		D6349CD82BC3AAEF002BAE5D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D6349CB92BC3AAED002BAE5D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = D6349CC02BC3AAED002BAE5D;
+			remoteInfo = ToDoListApp;
+		};
+		D6349CE22BC3AAEF002BAE5D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D6349CB92BC3AAED002BAE5D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = D6349CC02BC3AAED002BAE5D;
+			remoteInfo = ToDoListApp;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		D6349CC12BC3AAED002BAE5D /* ToDoListApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ToDoListApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		D6349CC42BC3AAED002BAE5D /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		D6349CC62BC3AAED002BAE5D /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		D6349CC82BC3AAED002BAE5D /* MainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewController.swift; sourceTree = "<group>"; };
+		D6349CCB2BC3AAED002BAE5D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		D6349CCD2BC3AAEE002BAE5D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		D6349CD02BC3AAEE002BAE5D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		D6349CD22BC3AAEE002BAE5D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		D6349CD72BC3AAEF002BAE5D /* ToDoListAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ToDoListAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		D6349CDB2BC3AAEF002BAE5D /* ToDoListAppTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToDoListAppTests.swift; sourceTree = "<group>"; };
+		D6349CE12BC3AAEF002BAE5D /* ToDoListAppUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ToDoListAppUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		D6349CE52BC3AAEF002BAE5D /* ToDoListAppUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToDoListAppUITests.swift; sourceTree = "<group>"; };
+		D6349CE72BC3AAEF002BAE5D /* ToDoListAppUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToDoListAppUITestsLaunchTests.swift; sourceTree = "<group>"; };
+		D6349CF42BC3C8B8002BAE5D /* CardListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardListViewController.swift; sourceTree = "<group>"; };
+		D6349CF62BC3C918002BAE5D /* CardListHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardListHeaderView.swift; sourceTree = "<group>"; };
+		D6349CF82BC3DE2B002BAE5D /* CardTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardTableViewCell.swift; sourceTree = "<group>"; };
+		D6349CF92BC3DE2B002BAE5D /* CardTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CardTableViewCell.xib; sourceTree = "<group>"; };
+		D6349CFC2BC4D45C002BAE5D /* TodoCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoCard.swift; sourceTree = "<group>"; };
+		D6349D022BC4FA37002BAE5D /* ContainerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerViewController.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		D6349CBE2BC3AAED002BAE5D /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D6349CD42BC3AAEF002BAE5D /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D6349CDE2BC3AAEF002BAE5D /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		D6349CB82BC3AAED002BAE5D = {
+			isa = PBXGroup;
+			children = (
+				D6349CC32BC3AAED002BAE5D /* ToDoListApp */,
+				D6349CDA2BC3AAEF002BAE5D /* ToDoListAppTests */,
+				D6349CE42BC3AAEF002BAE5D /* ToDoListAppUITests */,
+				D6349CC22BC3AAED002BAE5D /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		D6349CC22BC3AAED002BAE5D /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				D6349CC12BC3AAED002BAE5D /* ToDoListApp.app */,
+				D6349CD72BC3AAEF002BAE5D /* ToDoListAppTests.xctest */,
+				D6349CE12BC3AAEF002BAE5D /* ToDoListAppUITests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		D6349CC32BC3AAED002BAE5D /* ToDoListApp */ = {
+			isa = PBXGroup;
+			children = (
+				D6349CC42BC3AAED002BAE5D /* AppDelegate.swift */,
+				D6349CC62BC3AAED002BAE5D /* SceneDelegate.swift */,
+				D6349CC82BC3AAED002BAE5D /* MainViewController.swift */,
+				D6349D022BC4FA37002BAE5D /* ContainerViewController.swift */,
+				D6349CFF2BC4DDFC002BAE5D /* CardList */,
+				D6349CFE2BC4D460002BAE5D /* Model */,
+				D6349CCA2BC3AAED002BAE5D /* Main.storyboard */,
+				D6349CCD2BC3AAEE002BAE5D /* Assets.xcassets */,
+				D6349CCF2BC3AAEE002BAE5D /* LaunchScreen.storyboard */,
+				D6349CD22BC3AAEE002BAE5D /* Info.plist */,
+			);
+			path = ToDoListApp;
+			sourceTree = "<group>";
+		};
+		D6349CDA2BC3AAEF002BAE5D /* ToDoListAppTests */ = {
+			isa = PBXGroup;
+			children = (
+				D6349CDB2BC3AAEF002BAE5D /* ToDoListAppTests.swift */,
+			);
+			path = ToDoListAppTests;
+			sourceTree = "<group>";
+		};
+		D6349CE42BC3AAEF002BAE5D /* ToDoListAppUITests */ = {
+			isa = PBXGroup;
+			children = (
+				D6349CE52BC3AAEF002BAE5D /* ToDoListAppUITests.swift */,
+				D6349CE72BC3AAEF002BAE5D /* ToDoListAppUITestsLaunchTests.swift */,
+			);
+			path = ToDoListAppUITests;
+			sourceTree = "<group>";
+		};
+		D6349CFE2BC4D460002BAE5D /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				D6349CFC2BC4D45C002BAE5D /* TodoCard.swift */,
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
+		D6349CFF2BC4DDFC002BAE5D /* CardList */ = {
+			isa = PBXGroup;
+			children = (
+				D6349CF62BC3C918002BAE5D /* CardListHeaderView.swift */,
+				D6349CF42BC3C8B8002BAE5D /* CardListViewController.swift */,
+				D6349CF82BC3DE2B002BAE5D /* CardTableViewCell.swift */,
+				D6349CF92BC3DE2B002BAE5D /* CardTableViewCell.xib */,
+			);
+			path = CardList;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		D6349CC02BC3AAED002BAE5D /* ToDoListApp */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D6349CEB2BC3AAEF002BAE5D /* Build configuration list for PBXNativeTarget "ToDoListApp" */;
+			buildPhases = (
+				D6349CBD2BC3AAED002BAE5D /* Sources */,
+				D6349CBE2BC3AAED002BAE5D /* Frameworks */,
+				D6349CBF2BC3AAED002BAE5D /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ToDoListApp;
+			productName = ToDoListApp;
+			productReference = D6349CC12BC3AAED002BAE5D /* ToDoListApp.app */;
+			productType = "com.apple.product-type.application";
+		};
+		D6349CD62BC3AAEF002BAE5D /* ToDoListAppTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D6349CEE2BC3AAEF002BAE5D /* Build configuration list for PBXNativeTarget "ToDoListAppTests" */;
+			buildPhases = (
+				D6349CD32BC3AAEF002BAE5D /* Sources */,
+				D6349CD42BC3AAEF002BAE5D /* Frameworks */,
+				D6349CD52BC3AAEF002BAE5D /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				D6349CD92BC3AAEF002BAE5D /* PBXTargetDependency */,
+			);
+			name = ToDoListAppTests;
+			productName = ToDoListAppTests;
+			productReference = D6349CD72BC3AAEF002BAE5D /* ToDoListAppTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		D6349CE02BC3AAEF002BAE5D /* ToDoListAppUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D6349CF12BC3AAEF002BAE5D /* Build configuration list for PBXNativeTarget "ToDoListAppUITests" */;
+			buildPhases = (
+				D6349CDD2BC3AAEF002BAE5D /* Sources */,
+				D6349CDE2BC3AAEF002BAE5D /* Frameworks */,
+				D6349CDF2BC3AAEF002BAE5D /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				D6349CE32BC3AAEF002BAE5D /* PBXTargetDependency */,
+			);
+			name = ToDoListAppUITests;
+			productName = ToDoListAppUITests;
+			productReference = D6349CE12BC3AAEF002BAE5D /* ToDoListAppUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		D6349CB92BC3AAED002BAE5D /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1530;
+				LastUpgradeCheck = 1530;
+				TargetAttributes = {
+					D6349CC02BC3AAED002BAE5D = {
+						CreatedOnToolsVersion = 15.3;
+					};
+					D6349CD62BC3AAEF002BAE5D = {
+						CreatedOnToolsVersion = 15.3;
+						TestTargetID = D6349CC02BC3AAED002BAE5D;
+					};
+					D6349CE02BC3AAEF002BAE5D = {
+						CreatedOnToolsVersion = 15.3;
+						TestTargetID = D6349CC02BC3AAED002BAE5D;
+					};
+				};
+			};
+			buildConfigurationList = D6349CBC2BC3AAED002BAE5D /* Build configuration list for PBXProject "ToDoListApp" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = D6349CB82BC3AAED002BAE5D;
+			productRefGroup = D6349CC22BC3AAED002BAE5D /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				D6349CC02BC3AAED002BAE5D /* ToDoListApp */,
+				D6349CD62BC3AAEF002BAE5D /* ToDoListAppTests */,
+				D6349CE02BC3AAEF002BAE5D /* ToDoListAppUITests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		D6349CBF2BC3AAED002BAE5D /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D6349CCE2BC3AAEE002BAE5D /* Assets.xcassets in Resources */,
+				D6349CD12BC3AAEE002BAE5D /* Base in Resources */,
+				D6349CCC2BC3AAED002BAE5D /* Base in Resources */,
+				D6349CFA2BC3DE2B002BAE5D /* CardTableViewCell.xib in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D6349CD52BC3AAEF002BAE5D /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D6349CDF2BC3AAEF002BAE5D /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		D6349CBD2BC3AAED002BAE5D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D6349CF52BC3C8B8002BAE5D /* CardListViewController.swift in Sources */,
+				D6349CFD2BC4D45C002BAE5D /* TodoCard.swift in Sources */,
+				D6349CFB2BC3DE2B002BAE5D /* CardTableViewCell.swift in Sources */,
+				D6349CC92BC3AAED002BAE5D /* MainViewController.swift in Sources */,
+				D6349CC52BC3AAED002BAE5D /* AppDelegate.swift in Sources */,
+				D6349CC72BC3AAED002BAE5D /* SceneDelegate.swift in Sources */,
+				D6349D032BC4FA37002BAE5D /* ContainerViewController.swift in Sources */,
+				D6349CF72BC3C918002BAE5D /* CardListHeaderView.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D6349CD32BC3AAEF002BAE5D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D6349CDC2BC3AAEF002BAE5D /* ToDoListAppTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D6349CDD2BC3AAEF002BAE5D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D6349CE82BC3AAEF002BAE5D /* ToDoListAppUITestsLaunchTests.swift in Sources */,
+				D6349CE62BC3AAEF002BAE5D /* ToDoListAppUITests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		D6349CD92BC3AAEF002BAE5D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = D6349CC02BC3AAED002BAE5D /* ToDoListApp */;
+			targetProxy = D6349CD82BC3AAEF002BAE5D /* PBXContainerItemProxy */;
+		};
+		D6349CE32BC3AAEF002BAE5D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = D6349CC02BC3AAED002BAE5D /* ToDoListApp */;
+			targetProxy = D6349CE22BC3AAEF002BAE5D /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		D6349CCA2BC3AAED002BAE5D /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				D6349CCB2BC3AAED002BAE5D /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		D6349CCF2BC3AAEE002BAE5D /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				D6349CD02BC3AAEE002BAE5D /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		D6349CE92BC3AAEF002BAE5D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.4;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		D6349CEA2BC3AAEF002BAE5D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.4;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		D6349CEC2BC3AAEF002BAE5D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 9H57LB393L;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = ToDoListApp/Info.plist;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UIMainStoryboardFile = Main;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = pro.ToDoListApp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 2;
+			};
+			name = Debug;
+		};
+		D6349CED2BC3AAEF002BAE5D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 9H57LB393L;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = ToDoListApp/Info.plist;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UIMainStoryboardFile = Main;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = pro.ToDoListApp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 2;
+			};
+			name = Release;
+		};
+		D6349CEF2BC3AAEF002BAE5D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 9H57LB393L;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.4;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = pro.ToDoListAppTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ToDoListApp.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/ToDoListApp";
+			};
+			name = Debug;
+		};
+		D6349CF02BC3AAEF002BAE5D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 9H57LB393L;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.4;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = pro.ToDoListAppTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ToDoListApp.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/ToDoListApp";
+			};
+			name = Release;
+		};
+		D6349CF22BC3AAEF002BAE5D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 9H57LB393L;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = pro.ToDoListAppUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = ToDoListApp;
+			};
+			name = Debug;
+		};
+		D6349CF32BC3AAEF002BAE5D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 9H57LB393L;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = pro.ToDoListAppUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = ToDoListApp;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		D6349CBC2BC3AAED002BAE5D /* Build configuration list for PBXProject "ToDoListApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D6349CE92BC3AAEF002BAE5D /* Debug */,
+				D6349CEA2BC3AAEF002BAE5D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		D6349CEB2BC3AAEF002BAE5D /* Build configuration list for PBXNativeTarget "ToDoListApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D6349CEC2BC3AAEF002BAE5D /* Debug */,
+				D6349CED2BC3AAEF002BAE5D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		D6349CEE2BC3AAEF002BAE5D /* Build configuration list for PBXNativeTarget "ToDoListAppTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D6349CEF2BC3AAEF002BAE5D /* Debug */,
+				D6349CF02BC3AAEF002BAE5D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		D6349CF12BC3AAEF002BAE5D /* Build configuration list for PBXNativeTarget "ToDoListAppUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D6349CF22BC3AAEF002BAE5D /* Debug */,
+				D6349CF32BC3AAEF002BAE5D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = D6349CB92BC3AAED002BAE5D /* Project object */;
+}

--- a/ToDoListApp/ToDoListApp.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/ToDoListApp/ToDoListApp.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/ToDoListApp/ToDoListApp.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/ToDoListApp/ToDoListApp.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/ToDoListApp/ToDoListApp/AppDelegate.swift
+++ b/ToDoListApp/ToDoListApp/AppDelegate.swift
@@ -1,0 +1,14 @@
+//
+//  AppDelegate.swift
+//  ToDoListApp
+//
+//  Created by 조호근 on 4/8/24.
+//
+
+import UIKit
+
+@main
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+}
+

--- a/ToDoListApp/ToDoListApp/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/ToDoListApp/ToDoListApp/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ToDoListApp/ToDoListApp/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/ToDoListApp/ToDoListApp/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ToDoListApp/ToDoListApp/Assets.xcassets/Contents.json
+++ b/ToDoListApp/ToDoListApp/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ToDoListApp/ToDoListApp/Base.lproj/LaunchScreen.storyboard
+++ b/ToDoListApp/ToDoListApp/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/ToDoListApp/ToDoListApp/Base.lproj/Main.storyboard
+++ b/ToDoListApp/ToDoListApp/Base.lproj/Main.storyboard
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="75G-Qm-Nrd">
+    <device id="ipad10_9rounded" orientation="landscape" layout="fullscreen" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22684"/>
+        <capability name="Image references" minToolsVersion="12.0"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Main View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController storyboardIdentifier="MainViewController" id="BYZ-38-t0r" customClass="MainViewController" customModule="ToDoListApp" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="1180" height="820"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                    <navigationItem key="navigationItem" id="M71-Md-hub">
+                        <barButtonItem key="leftBarButtonItem" style="plain" id="f6A-GX-jsh">
+                            <view key="customView" contentMode="scaleToFill" id="jf8-2W-bd2">
+                                <rect key="frame" x="20" y="6.5" width="262" height="37"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="TO-DO LIST" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xAk-T1-Uvd">
+                                        <rect key="frame" x="0.0" y="0.0" width="262" height="37"/>
+                                        <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="47"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <constraints>
+                                    <constraint firstAttribute="bottom" secondItem="xAk-T1-Uvd" secondAttribute="bottom" id="KfR-WA-ct3"/>
+                                    <constraint firstAttribute="trailing" secondItem="xAk-T1-Uvd" secondAttribute="trailing" id="Tqc-qa-uZD"/>
+                                    <constraint firstItem="xAk-T1-Uvd" firstAttribute="leading" secondItem="jf8-2W-bd2" secondAttribute="leading" id="q93-nN-LhE"/>
+                                    <constraint firstItem="xAk-T1-Uvd" firstAttribute="top" secondItem="jf8-2W-bd2" secondAttribute="top" id="rPu-BR-qFJ"/>
+                                </constraints>
+                            </view>
+                        </barButtonItem>
+                        <barButtonItem key="rightBarButtonItem" title="Item" id="vNC-XQ-MKV">
+                            <imageReference key="image" image="line.3.horizontal" catalog="system" symbolScale="large" renderingMode="hierarchical-single">
+                                <hierarchicalColors>
+                                    <color systemColor="labelColor"/>
+                                    <color systemColor="secondaryLabelColor"/>
+                                    <color systemColor="tertiaryLabelColor"/>
+                                </hierarchicalColors>
+                            </imageReference>
+                            <connections>
+                                <segue destination="W0O-Q2-dNA" kind="popoverPresentation" popoverAnchorBarButtonItem="vNC-XQ-MKV" id="zcj-bj-KkY">
+                                    <popoverArrowDirection key="popoverArrowDirection" up="YES" down="YES" left="YES" right="YES"/>
+                                </segue>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="754" y="-119"/>
+        </scene>
+        <!--Table View Controller-->
+        <scene sceneID="bhl-hj-3Q1">
+            <objects>
+                <tableViewController id="W0O-Q2-dNA" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" id="wb8-jK-0Zc">
+                        <rect key="frame" x="0.0" y="0.0" width="300" height="800"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <prototypes>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="ewH-WP-LIj">
+                                <rect key="frame" x="0.0" y="50" width="300" height="44.5"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ewH-WP-LIj" id="zMo-em-iZR">
+                                    <rect key="frame" x="0.0" y="0.0" width="300" height="44.5"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                </tableViewCellContentView>
+                            </tableViewCell>
+                        </prototypes>
+                        <connections>
+                            <outlet property="dataSource" destination="W0O-Q2-dNA" id="d8b-fR-Dbj"/>
+                            <outlet property="delegate" destination="W0O-Q2-dNA" id="XSi-UY-i55"/>
+                        </connections>
+                    </tableView>
+                    <size key="freeformSize" width="300" height="820"/>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="MyZ-Ba-VMp" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1298" y="-120"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="ivq-Ox-jy1">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="75G-Qm-Nrd" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="89a-fy-Kfb">
+                        <rect key="frame" x="0.0" y="24" width="1180" height="50"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="BYZ-38-t0r" kind="relationship" relationship="rootViewController" id="WOA-ZX-kal"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="3Xi-8k-81C" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="15.76271186440678" y="-118.53658536585365"/>
+        </scene>
+    </scenes>
+    <resources>
+        <image name="line.3.horizontal" catalog="system" width="128" height="65"/>
+        <systemColor name="labelColor">
+            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="secondaryLabelColor">
+            <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemGray5Color">
+            <color red="0.89803921568627454" green="0.89803921568627454" blue="0.91764705882352937" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="tertiaryLabelColor">
+            <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.29803921568627451" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+    </resources>
+</document>

--- a/ToDoListApp/ToDoListApp/CardList/CardListHeaderView.swift
+++ b/ToDoListApp/ToDoListApp/CardList/CardListHeaderView.swift
@@ -29,11 +29,12 @@ class CardListHeaderView: UIView {
         return badgeLabel
     }()
     
-    private let addButton: UIButton = {
+    private lazy var addButton: UIButton = { [unowned self] in
         let button = UIButton(type: .system)
         button.setTitle("+", for: .normal)
-        button.setTitleColor(.black, for: .normal)
-        button.addTarget(CardListHeaderView.self, action: #selector(addButtonTapped), for: .touchUpInside)
+        button.setTitleColor(.systemGray2, for: .normal)
+        button.titleLabel?.font = UIFont.systemFont(ofSize: 30)
+        button.addTarget(self, action: #selector(addButtonTapped), for: .touchUpInside)
         button.translatesAutoresizingMaskIntoConstraints = false
         return button
     }()
@@ -66,7 +67,7 @@ class CardListHeaderView: UIView {
             badgeLabel.widthAnchor.constraint(greaterThanOrEqualTo: badgeLabel.heightAnchor),
             
             addButton.centerYAnchor.constraint(equalTo: badgeLabel.centerYAnchor),
-            addButton.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant:  -20)
+            addButton.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant:  -20),
         ])
     }
     

--- a/ToDoListApp/ToDoListApp/CardList/CardListHeaderView.swift
+++ b/ToDoListApp/ToDoListApp/CardList/CardListHeaderView.swift
@@ -1,0 +1,76 @@
+//
+//  CardListHeaderView.swift
+//  ToDoListApp
+//
+//  Created by 조호근 on 4/8/24.
+//
+
+import UIKit
+
+class CardListHeaderView: UIView {
+    let titleLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 20, weight: .bold)
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
+    var badgeLabel: UILabel = {
+        let badgeLabel = UILabel()
+        badgeLabel.layer.cornerRadius = 15
+        badgeLabel.layer.borderWidth = 1
+        badgeLabel.layer.borderColor = UIColor.black.cgColor
+        badgeLabel.backgroundColor = .systemGray5
+        badgeLabel.textColor = .black
+        badgeLabel.clipsToBounds = true
+        badgeLabel.textAlignment = .center
+        badgeLabel.text = "0"
+        badgeLabel.translatesAutoresizingMaskIntoConstraints = false
+        return badgeLabel
+    }()
+    
+    private let addButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.setTitle("+", for: .normal)
+        button.setTitleColor(.black, for: .normal)
+        button.addTarget(CardListHeaderView.self, action: #selector(addButtonTapped), for: .touchUpInside)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupView()
+        configureLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupView()
+        configureLayout()
+    }
+    
+    private func setupView() {
+        self.backgroundColor = .systemGray5
+        [ titleLabel, badgeLabel, addButton ].forEach { self.addSubview($0) }
+    }
+    
+    private func configureLayout() {
+        NSLayoutConstraint.activate([
+            titleLabel.centerYAnchor.constraint(equalTo: self.centerYAnchor),
+            titleLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 10),
+            
+            badgeLabel.centerYAnchor.constraint(equalTo: titleLabel.centerYAnchor),
+            badgeLabel.leadingAnchor.constraint(equalTo: titleLabel.trailingAnchor, constant: 10),
+            badgeLabel.heightAnchor.constraint(equalToConstant: 30),
+            badgeLabel.widthAnchor.constraint(greaterThanOrEqualTo: badgeLabel.heightAnchor),
+            
+            addButton.centerYAnchor.constraint(equalTo: badgeLabel.centerYAnchor),
+            addButton.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant:  -20)
+        ])
+    }
+    
+    @objc func addButtonTapped(sender: UIButton) {
+        print("헤더 add버튼 탭")
+    }
+}

--- a/ToDoListApp/ToDoListApp/CardList/CardListViewController.swift
+++ b/ToDoListApp/ToDoListApp/CardList/CardListViewController.swift
@@ -29,7 +29,7 @@ class CardListViewController: UIViewController {
         setupTableView()
     }
     
-    func setupStackView() {
+    private func setupStackView() {
         stackView = UIStackView()
         stackView.axis = .vertical
         stackView.distribution = .fill
@@ -53,7 +53,7 @@ class CardListViewController: UIViewController {
         headerView.heightAnchor.constraint(equalToConstant: 80).isActive = true
     }
     
-    func setupTableView() {
+    private func setupTableView() {
         tableView = UITableView(frame: .zero, style: .plain)
         tableView.separatorStyle = .none
         tableView.backgroundColor = .systemGray5

--- a/ToDoListApp/ToDoListApp/CardList/CardListViewController.swift
+++ b/ToDoListApp/ToDoListApp/CardList/CardListViewController.swift
@@ -1,0 +1,93 @@
+//
+//  CardListViewController.swift
+//  ToDoListApp
+//
+//  Created by 조호근 on 4/8/24.
+//
+
+import UIKit
+
+class CardListViewController: UIViewController {
+    var tableView: UITableView!
+    var stackView: UIStackView!
+    let headerTitle: String
+    var cards: [ToDoCard]
+    
+    init(headerTitle: String, cards: [ToDoCard] = []) {
+        self.headerTitle = headerTitle
+        self.cards = cards
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupStackView()
+        setupTableView()
+    }
+    
+    func setupStackView() {
+        stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.distribution = .fill
+        stackView.alignment = .fill
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(stackView)
+        
+        NSLayoutConstraint.activate([
+            stackView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            stackView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+            stackView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+            stackView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
+        ])
+        
+        let headerView = CardListHeaderView()
+        headerView.titleLabel.text = headerTitle
+        headerView.badgeLabel.text = "\(cards.count)"
+        headerView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.addArrangedSubview(headerView)
+        
+        headerView.heightAnchor.constraint(equalToConstant: 80).isActive = true
+    }
+    
+    func setupTableView() {
+        tableView = UITableView(frame: .zero, style: .plain)
+        tableView.separatorStyle = .none
+        tableView.backgroundColor = .systemGray5
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.addArrangedSubview(tableView)
+        
+        tableView.rowHeight = UITableView.automaticDimension
+        tableView.estimatedRowHeight = 100
+        tableView.dataSource = self
+        tableView.delegate = self
+        
+        let nib = UINib(nibName: "CardTableViewCell", bundle: nil)
+        tableView.register(nib, forCellReuseIdentifier: "CardTableViewCell")
+    }
+}
+
+extension CardListViewController: UITableViewDataSource, UITableViewDelegate {
+    // MARK: - dataSource
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return cards.count
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "CardTableViewCell", for: indexPath) as! CardTableViewCell
+        let card = cards[indexPath.row]
+        cell.configure(with: card)
+        return cell
+    }
+    
+    // MARK: - delegate
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        print("\(headerTitle): \(indexPath.row)")
+    }
+}
+
+

--- a/ToDoListApp/ToDoListApp/CardList/CardTableViewCell.swift
+++ b/ToDoListApp/ToDoListApp/CardList/CardTableViewCell.swift
@@ -1,0 +1,41 @@
+//
+//  CardTableViewCell.swift
+//  ToDoListApp
+//
+//  Created by 조호근 on 4/8/24.
+//
+
+import UIKit
+
+class CardTableViewCell: UITableViewCell {
+
+    @IBOutlet weak var titleLabel: UILabel!
+    @IBOutlet weak var descriptionLabel: UILabel!
+    @IBOutlet weak var platformLabel: UILabel!
+    @IBOutlet weak var cardBackgroundView: UIView!
+    
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        setupView()
+    }
+
+    override func setSelected(_ selected: Bool, animated: Bool) {
+        super.setSelected(selected, animated: animated)
+
+    }
+    
+    func setupView() {
+        descriptionLabel.numberOfLines = 3
+        descriptionLabel.lineBreakMode = .byWordWrapping
+        
+        cardBackgroundView.layer.cornerRadius = 10
+        cardBackgroundView.clipsToBounds = true
+        
+    }
+    
+    func configure(with card: ToDoCard) {
+        titleLabel.text = card.title
+        descriptionLabel.text = card.description
+        platformLabel.text = "author by \(card.platform)"
+    }
+}

--- a/ToDoListApp/ToDoListApp/CardList/CardTableViewCell.xib
+++ b/ToDoListApp/ToDoListApp/CardList/CardTableViewCell.xib
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="ipad10_9rounded" orientation="portrait" layout="fullscreen" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22684"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" restorationIdentifier="CardTableViewCell" selectionStyle="default" indentationWidth="10" rowHeight="148" id="KGk-i7-Jjw" customClass="CardTableViewCell" customModule="ToDoListApp" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="380" height="148"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+                <rect key="frame" x="0.0" y="0.0" width="380" height="148"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="KHw-jk-GZd">
+                        <rect key="frame" x="0.0" y="0.0" width="380" height="132"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7hO-mh-dIr">
+                                <rect key="frame" x="16" y="16" width="348" height="20"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="20" id="UeH-wY-erW"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="18"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="f06-PV-17Z">
+                                <rect key="frame" x="16" y="99" width="348" height="17"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <color key="textColor" systemColor="systemGrayColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="C8Z-B5-aMb">
+                                <rect key="frame" x="16" y="44" width="348" height="47"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="46" id="dOM-xh-MQF"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstAttribute="trailing" secondItem="C8Z-B5-aMb" secondAttribute="trailing" constant="16" id="0Ef-Uf-ThA"/>
+                            <constraint firstAttribute="trailing" secondItem="7hO-mh-dIr" secondAttribute="trailing" constant="16" id="SBN-UW-gue"/>
+                            <constraint firstAttribute="trailing" secondItem="f06-PV-17Z" secondAttribute="trailing" constant="16" id="U3t-fR-Wry"/>
+                            <constraint firstItem="C8Z-B5-aMb" firstAttribute="leading" secondItem="KHw-jk-GZd" secondAttribute="leading" constant="16" id="ZIW-88-9LG"/>
+                            <constraint firstItem="7hO-mh-dIr" firstAttribute="leading" secondItem="KHw-jk-GZd" secondAttribute="leading" constant="16" id="ke7-XQ-80a"/>
+                            <constraint firstItem="7hO-mh-dIr" firstAttribute="top" secondItem="KHw-jk-GZd" secondAttribute="top" constant="16" id="qL9-l3-hWJ"/>
+                            <constraint firstItem="f06-PV-17Z" firstAttribute="top" secondItem="C8Z-B5-aMb" secondAttribute="bottom" constant="8" id="rBv-Xe-HdS"/>
+                            <constraint firstItem="C8Z-B5-aMb" firstAttribute="top" secondItem="7hO-mh-dIr" secondAttribute="bottom" constant="8" id="t6W-PJ-v0G"/>
+                            <constraint firstAttribute="bottom" secondItem="f06-PV-17Z" secondAttribute="bottom" constant="16" id="xkA-83-LuU"/>
+                            <constraint firstItem="f06-PV-17Z" firstAttribute="leading" secondItem="KHw-jk-GZd" secondAttribute="leading" constant="16" id="zqt-WY-Suo"/>
+                        </constraints>
+                    </view>
+                </subviews>
+                <color key="backgroundColor" systemColor="systemGray5Color"/>
+                <constraints>
+                    <constraint firstItem="KHw-jk-GZd" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="eyV-h4-5pH"/>
+                    <constraint firstAttribute="trailing" secondItem="KHw-jk-GZd" secondAttribute="trailing" id="sfP-PH-bbo"/>
+                    <constraint firstItem="KHw-jk-GZd" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="wgU-dI-Ahh"/>
+                    <constraint firstAttribute="bottom" secondItem="KHw-jk-GZd" secondAttribute="bottom" constant="16" id="xzU-Fm-bb7"/>
+                </constraints>
+            </tableViewCellContentView>
+            <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+            <connections>
+                <outlet property="cardBackgroundView" destination="KHw-jk-GZd" id="q3g-ia-W0k"/>
+                <outlet property="descriptionLabel" destination="C8Z-B5-aMb" id="2Ic-bg-Nh0"/>
+                <outlet property="platformLabel" destination="f06-PV-17Z" id="jOC-1y-7v4"/>
+                <outlet property="titleLabel" destination="7hO-mh-dIr" id="YZg-4F-ebr"/>
+            </connections>
+            <point key="canvasLocation" x="-45" y="47"/>
+        </tableViewCell>
+    </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemGray5Color">
+            <color red="0.89803921568627454" green="0.89803921568627454" blue="0.91764705882352937" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemGrayColor">
+            <color red="0.55686274509803924" green="0.55686274509803924" blue="0.57647058823529407" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+    </resources>
+</document>

--- a/ToDoListApp/ToDoListApp/CardList/ContainerViewController.swift
+++ b/ToDoListApp/ToDoListApp/CardList/ContainerViewController.swift
@@ -20,7 +20,7 @@ class ContainerViewController: UIViewController {
     private func setupStackView() {
         stackView.axis = .horizontal
         stackView.distribution = .fillEqually
-        stackView.spacing = 10
+        stackView.spacing = 30
         stackView.alignment = .fill
         stackView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(stackView)
@@ -42,9 +42,6 @@ class ContainerViewController: UIViewController {
             addChild(cardListVC)
             stackView.addArrangedSubview(cardListVC.view)
             cardListVC.didMove(toParent: self)
-            
-            cardListVC.view.translatesAutoresizingMaskIntoConstraints = false
-            cardListVC.view.widthAnchor.constraint(equalTo: view.widthAnchor, multiplier: 1/3, constant: -20/3).isActive = true
         }
     }
 }

--- a/ToDoListApp/ToDoListApp/ContainerViewController.swift
+++ b/ToDoListApp/ToDoListApp/ContainerViewController.swift
@@ -1,0 +1,50 @@
+//
+//  ContainerViewController.swift
+//  ToDoListApp
+//
+//  Created by 조호근 on 4/9/24.
+//
+
+import UIKit
+
+class ContainerViewController: UIViewController {
+    private let stackView = UIStackView()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .systemGray5
+        setupStackView()
+        addTempCardListControllers()
+    }
+    
+    private func setupStackView() {
+        stackView.axis = .horizontal
+        stackView.distribution = .fillEqually
+        stackView.spacing = 10
+        stackView.alignment = .fill
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(stackView)
+
+        NSLayoutConstraint.activate([
+            stackView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            stackView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+            stackView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+            stackView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
+        ])
+    }
+    
+    private func addTempCardListControllers() {
+        let titles = ["해야할 일", "하고 있는 일", "완료한 일"]
+        let tempData = [ToDoCard(title: "안녕하세요", description: "안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요", platform: "iOS", status: .done),
+                        ToDoCard(title: "안녕하세요", description: "안녕하세요", platform: "iOS", status: .done)]
+        titles.forEach { title in
+            let cardListVC = CardListViewController(headerTitle: title, cards: tempData)
+            addChild(cardListVC)
+            stackView.addArrangedSubview(cardListVC.view)
+            cardListVC.didMove(toParent: self)
+            
+            cardListVC.view.translatesAutoresizingMaskIntoConstraints = false
+            cardListVC.view.widthAnchor.constraint(equalTo: view.widthAnchor, multiplier: 1/3, constant: -20/3).isActive = true
+        }
+    }
+}

--- a/ToDoListApp/ToDoListApp/Info.plist
+++ b/ToDoListApp/ToDoListApp/Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/ToDoListApp/ToDoListApp/MainViewController.swift
+++ b/ToDoListApp/ToDoListApp/MainViewController.swift
@@ -1,0 +1,36 @@
+//
+//  MainViewController.swift
+//  ToDoListApp
+//
+//  Created by 조호근 on 4/8/24.
+//
+
+import UIKit
+
+class MainViewController: UIViewController {
+    
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .systemGray5
+        displayContainerViewController()
+    }
+    
+    private func displayContainerViewController() {
+        let containerVC = ContainerViewController()
+        addChild(containerVC)
+        view.addSubview(containerVC.view)
+        containerVC.didMove(toParent: self)
+        
+        containerVC.view.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            containerVC.view.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            containerVC.view.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 20),
+            containerVC.view.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -300),
+            containerVC.view.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
+        ])
+    }
+    
+
+}
+

--- a/ToDoListApp/ToDoListApp/Model/TodoCard.swift
+++ b/ToDoListApp/ToDoListApp/Model/TodoCard.swift
@@ -1,0 +1,21 @@
+//
+//  TodoCard.swift
+//  ToDoListApp
+//
+//  Created by 조호근 on 4/9/24.
+//
+
+import Foundation
+
+enum CardStatus {
+    case toDO
+    case inProgress
+    case done
+}
+
+struct ToDoCard {
+    let title: String
+    let description: String
+    let platform: String
+    let status: CardStatus
+}

--- a/ToDoListApp/ToDoListApp/SceneDelegate.swift
+++ b/ToDoListApp/ToDoListApp/SceneDelegate.swift
@@ -1,0 +1,18 @@
+//
+//  SceneDelegate.swift
+//  ToDoListApp
+//
+//  Created by 조호근 on 4/8/24.
+//
+
+import UIKit
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+
+    var window: UIWindow?
+
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        guard let _ = (scene as? UIWindowScene) else { return }
+    }
+}
+

--- a/ToDoListApp/ToDoListAppTests/ToDoListAppTests.swift
+++ b/ToDoListApp/ToDoListAppTests/ToDoListAppTests.swift
@@ -1,0 +1,36 @@
+//
+//  ToDoListAppTests.swift
+//  ToDoListAppTests
+//
+//  Created by 조호근 on 4/8/24.
+//
+
+import XCTest
+@testable import ToDoListApp
+
+final class ToDoListAppTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        // Any test you write for XCTest can be annotated as throws and async.
+        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
+        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}

--- a/ToDoListApp/ToDoListAppUITests/ToDoListAppUITests.swift
+++ b/ToDoListApp/ToDoListAppUITests/ToDoListAppUITests.swift
@@ -1,0 +1,41 @@
+//
+//  ToDoListAppUITests.swift
+//  ToDoListAppUITests
+//
+//  Created by 조호근 on 4/8/24.
+//
+
+import XCTest
+
+final class ToDoListAppUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+
+        // In UI tests it is usually best to stop immediately when a failure occurs.
+        continueAfterFailure = false
+
+        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // UI tests must launch the application that they test.
+        let app = XCUIApplication()
+        app.launch()
+
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+    func testLaunchPerformance() throws {
+        if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 7.0, *) {
+            // This measures how long it takes to launch your application.
+            measure(metrics: [XCTApplicationLaunchMetric()]) {
+                XCUIApplication().launch()
+            }
+        }
+    }
+}

--- a/ToDoListApp/ToDoListAppUITests/ToDoListAppUITestsLaunchTests.swift
+++ b/ToDoListApp/ToDoListAppUITests/ToDoListAppUITestsLaunchTests.swift
@@ -1,0 +1,32 @@
+//
+//  ToDoListAppUITestsLaunchTests.swift
+//  ToDoListAppUITests
+//
+//  Created by 조호근 on 4/8/24.
+//
+
+import XCTest
+
+final class ToDoListAppUITestsLaunchTests: XCTestCase {
+
+    override class var runsForEachTargetApplicationUIConfiguration: Bool {
+        true
+    }
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    func testLaunch() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        // Insert steps here to perform after app launch but before taking a screenshot,
+        // such as logging into a test account or navigating somewhere in the app
+
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = "Launch Screen"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+}


### PR DESCRIPTION
## 🎯주요 작업

- [x]  스토리보드에서 작업하기 - 오토레이 아웃 적용하기
- [x]  카드 리스트 화면은 상단에 제목/배지/추가 버튼과 카드 목록을 표시하는 TableVIew 구성
    - [x]  배지는 현재 카드 개수를 표시
    - [x]  모서리가 없이 표시하고 숫자가 늘어나면 iOS 기본 배지처럼 가운데 영역길어짐
    - [x]  카드 셀은 본문 내용을 3줄까지만 표시
        - [x]  1줄 - 3줄까지 늘어나면 셀 높이도 같이 (self-resizing) 늘어나도록 구현

## 📚학습 키워드

### Anchor

영어로 `닻` 이라는 뜻인데, 쉽게 View에 닻을 내려서 고정시킨다고 생각

### **container view 사용 방법**

1. parentVC.addChild(childVC): 특정 ViewController를 현재 ViewController의 자식으로 설정
2. parentVC.view.addSubview(childView): 추가된 childVC의 View가 보일 수 있도록 맨 앞으로 등장하게 하는 것
3. childVC.didMove(toParent: parentVC) / willMove: childVC입장에서는 언제 parentVC에 추가되는지 모르기 때문에, childVC에게 추가 및 제거 되는 시점을 알려주는 것 (willMove / didMove: 추가되기 전, 추가된 후)

## 💻고민과 해결

###  **Logging Error: Failed to initialize logging system. Log messages may be missing. If this issue persists, try setting IDEPreferLogStreaming=YES in the active scheme actions environment variables.에러발생**

[🧙‍♂️나의 해결] **`Product** -> **Scheme** -> **Edit Scheme → Arguments** 로 이동 -> **Arguments Passed On Launch** 에서 + 눌러서 아래와 같은 코드 입력 -> **Close** 클릭.`

### 네비게이션 스토리보드로 제목 커스텀하기

[🧙‍♂️나의 해결] 네비게이션바에 UIView 넣고 UILabel넣음

### **'self' refers to the method 'CardListHeaderView.self', which may be unexpected**

[🧙‍♂️나의 해결] self가 예상과 다르게 클래스 자체를 참조하고 있다는 경고

보통 클로저 내에서 self를 사용하면 순환참조, 메모리 누수가 발생할 수 있기 때문에 약한 참조로 캡쳐해야 한다. 

지금 상황은 self가 클래스 자체를 가리키는 것을 방지하기 위한 것.

unowned는 클로저의 생명주기 동안 항상 존재할 때 사용

weak는 클로저의 생명주기 동안 nil이 될 수 있을 때 사용

버튼은 뷰가 메모리에 존재하는 동안에 있기 때문에 [ unowned self ]를 사용함.

## 🤔결과
<img width="1077" alt="스크린샷 2024-04-10 오후 3 02 15" src="https://github.com/codesquad-members-2024/swift-todo/assets/104732020/9997f3ca-b0b6-44fa-8a9a-bc5a082154e8">
